### PR TITLE
adds marshalling for output severityString to ensure correct escaping

### DIFF
--- a/logmessage.go
+++ b/logmessage.go
@@ -39,7 +39,7 @@ type severityString struct {
 
 func (os *severityString) MarshalJSON() ([]byte, error) {
 	// Format String
-	str := fmt.Sprintf("\"%s%s\"", getLogPrefix(os.severity), os.str)
+	str := getLogPrefix(os.severity)+os.str
 
 	// Marshal String to escape quotes and return byte array + error
 	return json.Marshal(str)

--- a/logmessage.go
+++ b/logmessage.go
@@ -41,12 +41,8 @@ func (os *severityString) MarshalJSON() ([]byte, error) {
 	// Format String
 	str := fmt.Sprintf("\"%s%s\"", getLogPrefix(os.severity), os.str)
 
-	// Marshal String to escape quotes
-	bytes, err := json.Marshal(str)
-	if err != nil {
-		panic(err)
-	}
-	return bytes, nil
+	// Marshal String to escape quotes and return byte array + error
+	return json.Marshal(str)
 }
 
 // logMsg type consists of multiple log entries

--- a/logmessage.go
+++ b/logmessage.go
@@ -38,7 +38,15 @@ type severityString struct {
 }
 
 func (os *severityString) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s%s\"", getLogPrefix(os.severity), os.str)), nil
+	// Format String
+	str := fmt.Sprintf("\"%s%s\"", getLogPrefix(os.severity), os.str)
+
+	// Marshal String to escape quotes
+	bytes, err := json.Marshal(str)
+	if err != nil {
+		panic(err)
+	}
+	return bytes, nil
 }
 
 // logMsg type consists of multiple log entries


### PR DESCRIPTION
create formatted string
`str := fmt.Sprintf("\"%s%s\"", getLogPrefix(os.severity), os.str)`

marshal full string to ensure correct escaping
`bytes, err := json.Marshal(str)`

return escaped byte array
`return bytes, nil`